### PR TITLE
Refactor functions. Add realtime data sources.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ This is still a WIP and some functions might not work!
 # Usage
 
 Add the script to your html file and you are ready to go!
-All that you need to get going is some data, this goes in the `CHART COLUMNS` input.
+All that you need to get going is some data, this goes in the `Chart Data` input.
 
-	[
+	{"columns":[
 		['data1', 20, 200, 150, 300, 200],
 		['data2', 400, 500, 250, 700, 300],
-	]
+	]}
 
 ![Example](example.png)


### PR DESCRIPTION
Use specific versions of C3/D3.js.
Use CDN versions of C3/D3.js.
Remove unused ID setting.
Change "columns" to be "data". This allows us to send
rows, columns, or json in a dictionary.
Change "options" to be "text" instead of "calculated".
Add a "flow" boolean setting. Setting to true will use
chart.flow instead of chart.load.
Rename variable "myElement" to "element".
Change element class from "testing" to "c3-chart-container".
Move padding calculations into a function.
Add "objectStringToJson" function which converts "obj.toString()"
to proper JSON.
Parse "options" as either "obj.toString()" or JSON.
Send empty columns during rendering. Calculated fields are not
calculated until "onCalculatedValueChanged", which means that
putting datasource references in here will cause an error.
Handle "extend(options)" safely, without this an invalid option
will cause empty C3 widgets to be built.
Move chart creation into it's own function outside of render.
Check for chart type changes specifically and call transform.
Check for options changes and recreate the chart if options change.
Handle both load and flow methods of pushing data.
Remove "type" change check in "onCalculatedValueChanged". Type is
not a calculated value and won't be sent here.
Remove evals.
Remove debug prints.
Update README example.
